### PR TITLE
Create PHP skeleton for Unico Consult website

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,17 @@ project_refaire_site_unico/
 
 This repository was created with the typo `porjectrefaireisteunico`.
 The intended name is `project_refaire_site_unico`.
+
+## Available Pages
+
+- `public/index.php` - Homepage.
+- `public/services.php` - Service listing.
+- `public/team.php` - Team presentation.
+- `public/trust.php` - Client testimonials.
+- `public/contact.php` - Contact form (no email sending yet).
+- `admin/login.php` - Admin login.
+- `admin/index.php` - Protected admin area.
+
+## Database configuration
+
+Edit `includes/db.php` to match your local MySQL credentials.

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,19 @@
+<?php
+session_start();
+if (!isset($_SESSION['logged_in'])) {
+    header('Location: login.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Dashboard</title>
+</head>
+<body>
+<h2>Bienvenue dans l'admin</h2>
+<p>Tableau de bord à venir.</p>
+<a href="logout.php">Déconnexion</a>
+</body>
+</html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,28 @@
+<?php
+session_start();
+if (isset($_POST['username'], $_POST['password'])) {
+    if ($_POST['username'] === 'admin' && $_POST['password'] === 'password') {
+        $_SESSION['logged_in'] = true;
+        header('Location: index.php');
+        exit;
+    } else {
+        $error = 'Identifiants incorrects';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Connexion Admin</title>
+</head>
+<body>
+<h2>Connexion Admin</h2>
+<?php if (!empty($error)) echo '<p style="color:red">'.$error.'</p>'; ?>
+<form action="" method="post">
+    <input type="text" name="username" placeholder="Nom d'utilisateur" required>
+    <input type="password" name="password" placeholder="Mot de passe" required>
+    <button type="submit">Se connecter</button>
+</form>
+</body>
+</html>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,5 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');
+exit;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,23 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f9f9f9;
+    color: #333;
+}
+header {
+    background: #663399;
+    color: #fff;
+    padding: 1rem;
+}
+nav a {
+    color: #fff;
+    margin-right: 1rem;
+    text-decoration: none;
+}
+footer {
+    background: #eee;
+    text-align: center;
+    padding: 1rem;
+    margin-top: 2rem;
+}

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,0 +1,16 @@
+<?php
+$host = 'localhost';
+$db   = 'unico';
+$user = 'root';
+$pass = '';
+$options = [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+];
+
+try {
+    $pdo = new PDO("mysql:host=$host;dbname=$db;charset=utf8", $user, $pass, $options);
+} catch (PDOException $e) {
+    die('Database connection failed: ' . $e->getMessage());
+}
+?>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,0 +1,6 @@
+</main>
+<footer>
+    <p>&copy; <?php echo date('Y'); ?> Unico Consult</p>
+</footer>
+</body>
+</html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,23 @@
+<?php
+// Basic HTML head and open body
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Unico Consult</title>
+    <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+<header>
+    <h1>Unico Consult</h1>
+    <nav>
+        <a href="/public/index.php">Accueil</a>
+        <a href="/public/services.php">Services</a>
+        <a href="/public/team.php">Notre équipe</a>
+        <a href="/public/trust.php">Ils nous font confiance</a>
+        <a href="/public/contact.php">Contact</a>
+    </nav>
+</header>
+<main>

--- a/public/contact.php
+++ b/public/contact.php
@@ -1,0 +1,18 @@
+<?php include '../includes/header.php'; ?>
+<h2>Contact</h2>
+<form action="" method="post">
+    <label for="name">Nom</label>
+    <input type="text" name="name" id="name" required>
+
+    <label for="email">Email</label>
+    <input type="email" name="email" id="email" required>
+
+    <label for="subject">Sujet</label>
+    <input type="text" name="subject" id="subject" required>
+
+    <label for="message">Message</label>
+    <textarea name="message" id="message" required></textarea>
+
+    <button type="submit">Envoyer</button>
+</form>
+<?php include '../includes/footer.php'; ?>

--- a/public/index.php
+++ b/public/index.php
@@ -1,3 +1,4 @@
-<?php
-echo "Welcome to Unico Consult";
-?>
+<?php include '../includes/header.php'; ?>
+<h2>Votre business ? Notre challenge !</h2>
+<p>Bienvenue sur le site d'Unico Consult.</p>
+<?php include '../includes/footer.php'; ?>

--- a/public/services.php
+++ b/public/services.php
@@ -1,0 +1,4 @@
+<?php include '../includes/header.php'; ?>
+<h2>Nos Services</h2>
+<p>Liste des services à venir.</p>
+<?php include '../includes/footer.php'; ?>

--- a/public/team.php
+++ b/public/team.php
@@ -1,0 +1,4 @@
+<?php include '../includes/header.php'; ?>
+<h2>Notre Équipe</h2>
+<p>Présentation de l'équipe.</p>
+<?php include '../includes/footer.php'; ?>

--- a/public/trust.php
+++ b/public/trust.php
@@ -1,0 +1,4 @@
+<?php include '../includes/header.php'; ?>
+<h2>Ils nous font confiance</h2>
+<p>Témoignages et logos clients.</p>
+<?php include '../includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add header and footer templates
- add simple CSS
- implement admin login/logout and dashboard placeholder
- create basic public pages (home, services, team, trust, contact)
- add database connection script
- expand README with available pages and setup notes

## Testing
- `php` command not available, so PHP syntax checks were not run

------
https://chatgpt.com/codex/tasks/task_e_6840bb585ec0832db99a718d9ea2401e