### PR TITLE
Add SQL dump for XAMPP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the source code for rebuilding the **Unico Consult** we
 1. Install [XAMPP](https://www.apachefriends.org/index.html).
 2. Clone or copy this repository into your `htdocs` directory.
 3. Start Apache and MySQL from the XAMPP control panel.
-4. Create a database (for example `unico`) and import any provided SQL dump.
+4. Create a database (for example `unico`) and import `unico.sql` using phpMyAdmin.
 5. Navigate to `http://localhost/project_refaire_site_unico/public/` in your browser.
 
 ## Folder Structure (planned)
@@ -23,3 +23,37 @@ project_refaire_site_unico/
 
 This repository was created with the typo `porjectrefaireisteunico`.
 The intended name is `project_refaire_site_unico`.
+
+## Available Pages
+
+- `public/index.php` - Homepage.
+- `public/services.php` - Service listing.
+- `public/team.php` - Team presentation.
+- `public/trust.php` - Client testimonials.
+- `public/contact.php` - Contact form that stores messages in the database.
+- `admin/login.php` - Admin login.
+- `admin/index.php` - Protected admin area.
+- `admin/messages.php` - List of messages received from the contact form.
+
+## Database configuration
+
+Edit `includes/db.php` to match your local MySQL credentials.
+
+### Messages table
+
+Create a `messages` table in your database:
+
+```sql
+CREATE TABLE messages (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  subject VARCHAR(255) NOT NULL,
+  message TEXT NOT NULL,
+  status ENUM('Nouveau', 'En cours', 'Traité') DEFAULT 'Nouveau',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+An SQL dump (`unico.sql`) is included at the repository root. Import it to create the database and messages table automatically.
+

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,22 @@
+<?php
+session_start();
+if (!isset($_SESSION['logged_in'])) {
+    header('Location: login.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Dashboard</title>
+</head>
+<body>
+<h2>Bienvenue dans l'admin</h2>
+<p>Tableau de bord à venir.</p>
+<ul>
+    <li><a href="messages.php">Messages reçus</a></li>
+</ul>
+<a href="logout.php">Déconnexion</a>
+</body>
+</html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,28 @@
+<?php
+session_start();
+if (isset($_POST['username'], $_POST['password'])) {
+    if ($_POST['username'] === 'admin' && $_POST['password'] === 'password') {
+        $_SESSION['logged_in'] = true;
+        header('Location: index.php');
+        exit;
+    } else {
+        $error = 'Identifiants incorrects';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Connexion Admin</title>
+</head>
+<body>
+<h2>Connexion Admin</h2>
+<?php if (!empty($error)) echo '<p style="color:red">'.$error.'</p>'; ?>
+<form action="" method="post">
+    <input type="text" name="username" placeholder="Nom d'utilisateur" required>
+    <input type="password" name="password" placeholder="Mot de passe" required>
+    <button type="submit">Se connecter</button>
+</form>
+</body>
+</html>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,5 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');
+exit;

--- a/admin/messages.php
+++ b/admin/messages.php
@@ -1,0 +1,42 @@
+<?php
+session_start();
+if (!isset($_SESSION['logged_in'])) {
+    header('Location: login.php');
+    exit;
+}
+
+require '../includes/db.php';
+$stmt = $pdo->query('SELECT id, name, email, subject, status, created_at FROM messages ORDER BY created_at DESC');
+$messages = $stmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Messages reçus</title>
+</head>
+<body>
+<h2>Messages reçus</h2>
+<table border="1" cellspacing="0" cellpadding="5">
+    <tr>
+        <th>ID</th>
+        <th>Nom</th>
+        <th>Email</th>
+        <th>Sujet</th>
+        <th>Statut</th>
+        <th>Date</th>
+    </tr>
+    <?php foreach ($messages as $msg): ?>
+    <tr>
+        <td><?php echo htmlspecialchars($msg['id']); ?></td>
+        <td><?php echo htmlspecialchars($msg['name']); ?></td>
+        <td><?php echo htmlspecialchars($msg['email']); ?></td>
+        <td><?php echo htmlspecialchars($msg['subject']); ?></td>
+        <td><?php echo htmlspecialchars($msg['status']); ?></td>
+        <td><?php echo htmlspecialchars($msg['created_at']); ?></td>
+    </tr>
+    <?php endforeach; ?>
+</table>
+<a href="index.php">Retour au tableau de bord</a>
+</body>
+</html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,23 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f9f9f9;
+    color: #333;
+}
+header {
+    background: #663399;
+    color: #fff;
+    padding: 1rem;
+}
+nav a {
+    color: #fff;
+    margin-right: 1rem;
+    text-decoration: none;
+}
+footer {
+    background: #eee;
+    text-align: center;
+    padding: 1rem;
+    margin-top: 2rem;
+}

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,0 +1,16 @@
+<?php
+$host = 'localhost';
+$db   = 'unico';
+$user = 'root';
+$pass = '';
+$options = [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+];
+
+try {
+    $pdo = new PDO("mysql:host=$host;dbname=$db;charset=utf8", $user, $pass, $options);
+} catch (PDOException $e) {
+    die('Database connection failed: ' . $e->getMessage());
+}
+?>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,0 +1,6 @@
+</main>
+<footer>
+    <p>&copy; <?php echo date('Y'); ?> Unico Consult</p>
+</footer>
+</body>
+</html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,24 @@
+<?php
+// Basic HTML head and open body
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Unico Consult</title>
+    <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+<header>
+    <h1>Unico Consult</h1>
+    <nav>
+        <a href="/public/index.php">Accueil</a>
+        <a href="/public/services.php">Services</a>
+        <a href="/public/team.php">Notre équipe</a>
+        <a href="/public/trust.php">Ils nous font confiance</a>
+        <a href="/public/contact.php">Contact</a>
+        <a href="/admin/login.php">Admin</a>
+    </nav>
+</header>
+<main>

--- a/public/contact.php
+++ b/public/contact.php
@@ -1,0 +1,37 @@
+<?php
+require '../includes/db.php';
+$messageSent = false;
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'] ?? '';
+    $email = $_POST['email'] ?? '';
+    $subject = $_POST['subject'] ?? '';
+    $message = $_POST['message'] ?? '';
+
+    $stmt = $pdo->prepare('INSERT INTO messages (name, email, subject, message, status, created_at) VALUES (?, ?, ?, ?, "Nouveau", NOW())');
+    $stmt->execute([$name, $email, $subject, $message]);
+    $messageSent = true;
+}
+
+include '../includes/header.php';
+?>
+<h2>Contact</h2>
+<?php if ($messageSent): ?>
+    <p>Merci pour votre message&nbsp;!</p>
+<?php else: ?>
+    <form action="" method="post">
+        <label for="name">Nom</label>
+        <input type="text" name="name" id="name" required>
+
+        <label for="email">Email</label>
+        <input type="email" name="email" id="email" required>
+
+        <label for="subject">Sujet</label>
+        <input type="text" name="subject" id="subject" required>
+
+        <label for="message">Message</label>
+        <textarea name="message" id="message" required></textarea>
+
+        <button type="submit">Envoyer</button>
+    </form>
+<?php endif; ?>
+<?php include '../includes/footer.php'; ?>

--- a/public/index.php
+++ b/public/index.php
@@ -1,3 +1,4 @@
-<?php
-echo "Welcome to Unico Consult";
-?>
+<?php include '../includes/header.php'; ?>
+<h2>Votre business ? Notre challenge !</h2>
+<p>Bienvenue sur le site d'Unico Consult.</p>
+<?php include '../includes/footer.php'; ?>

--- a/public/services.php
+++ b/public/services.php
@@ -1,0 +1,4 @@
+<?php include '../includes/header.php'; ?>
+<h2>Nos Services</h2>
+<p>Liste des services à venir.</p>
+<?php include '../includes/footer.php'; ?>

--- a/public/team.php
+++ b/public/team.php
@@ -1,0 +1,4 @@
+<?php include '../includes/header.php'; ?>
+<h2>Notre Équipe</h2>
+<p>Présentation de l'équipe.</p>
+<?php include '../includes/footer.php'; ?>

--- a/public/trust.php
+++ b/public/trust.php
@@ -1,0 +1,4 @@
+<?php include '../includes/header.php'; ?>
+<h2>Ils nous font confiance</h2>
+<p>Témoignages et logos clients.</p>
+<?php include '../includes/footer.php'; ?>

--- a/unico.sql
+++ b/unico.sql
@@ -1,0 +1,15 @@
+-- SQL schema for Unico Consult project
+-- Create database and table for messages
+
+CREATE DATABASE IF NOT EXISTS unico CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE unico;
+
+CREATE TABLE IF NOT EXISTS messages (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  subject VARCHAR(255) NOT NULL,
+  message TEXT NOT NULL,
+  status ENUM('Nouveau', 'En cours', 'Traité') DEFAULT 'Nouveau',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- include a `unico.sql` dump for easy database creation
- mention the SQL file in the setup instructions

## Testing
- `php -l public/index.php` *(fails: command not found)*
- `php -l admin/index.php` *(fails: command not found)*
- `php -l includes/db.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bb585ec0832db99a718d9ea2401e