### PR TITLE
Add contact handling and admin messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,16 @@ This repository contains the source code for rebuilding the **Unico Consult** we
 ## Local Development (XAMPP)
 
 1. Install [XAMPP](https://www.apachefriends.org/index.html).
-2. Clone or copy this repository into your `htdocs` directory.
-3. Start Apache and MySQL from the XAMPP control panel.
-4. Create a database (for example `unico`) and import any provided SQL dump.
-5. Navigate to `http://localhost/project_refaire_site_unico/public/` in your browser.
+2. Clone or copy this repository into your `htdocs` directory (usually `C:\xampp\htdocs` on Windows).
+3. Start **Apache** and **MySQL** from the XAMPP control panel.
+4. Import the `database.sql` file to create the initial database:
+   - Open phpMyAdmin from the XAMPP panel.
+   - Create a database named `unico`.
+   - Use the "Import" tab to load `database.sql` located at the project root.
+5. Update the credentials in `includes/db.php` if your MySQL user or password differs from the defaults.
+6. Navigate to `http://localhost/project_refaire_site_unico/public/` in your browser to see the site.
 
-## Folder Structure (planned)
+## Folder Structure
 
 ```
 project_refaire_site_unico/
@@ -30,10 +34,18 @@ The intended name is `project_refaire_site_unico`.
 - `public/services.php` - Service listing.
 - `public/team.php` - Team presentation.
 - `public/trust.php` - Client testimonials.
-- `public/contact.php` - Contact form (no email sending yet).
+- `public/contact.php` - Contact form (stores messages and sends an email).
 - `admin/login.php` - Admin login.
-- `admin/index.php` - Protected admin area.
+- `admin/index.php` - Protected admin area with message count.
+- `admin/messages.php` - List contact form messages.
 
 ## Database configuration
 
 Edit `includes/db.php` to match your local MySQL credentials.
+
+## Working with Visual Studio Code
+
+1. Install [Visual Studio Code](https://code.visualstudio.com/).
+2. From Visual Studio Code, choose **File > Open Folder...** and select the cloned project directory.
+3. You can now edit the PHP files directly and use the built-in terminal to run Git commands.
+4. Refresh your browser after changes while XAMPP is running.

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,9 +1,10 @@
 <?php
-session_start();
-if (!isset($_SESSION['logged_in'])) {
-    header('Location: login.php');
-    exit;
-}
+require '../includes/auth.php';
+require '../includes/db.php';
+
+// Count messages in contact form
+$countStmt = $pdo->query('SELECT COUNT(*) FROM contacts');
+$messageCount = $countStmt->fetchColumn();
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -13,7 +14,10 @@ if (!isset($_SESSION['logged_in'])) {
 </head>
 <body>
 <h2>Bienvenue dans l'admin</h2>
-<p>Tableau de bord à venir.</p>
-<a href="logout.php">Déconnexion</a>
+<p>Vous avez <?php echo $messageCount; ?> message(s) de contact.</p>
+<nav>
+    <a href="messages.php">Voir les messages</a> |
+    <a href="logout.php">Déconnexion</a>
+</nav>
 </body>
 </html>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -3,3 +3,4 @@ session_start();
 session_destroy();
 header('Location: login.php');
 exit;
+?>

--- a/admin/messages.php
+++ b/admin/messages.php
@@ -1,0 +1,44 @@
+<?php
+require '../includes/auth.php';
+require '../includes/db.php';
+
+$stmt = $pdo->query('SELECT * FROM contacts ORDER BY created_at DESC');
+$messages = $stmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Messages</title>
+    <style>
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
+    </style>
+</head>
+<body>
+<h2>Messages reçus</h2>
+<table>
+    <thead>
+    <tr>
+        <th>Nom</th>
+        <th>Email</th>
+        <th>Sujet</th>
+        <th>Message</th>
+        <th>Date</th>
+    </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($messages as $msg): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($msg['name']); ?></td>
+            <td><?php echo htmlspecialchars($msg['email']); ?></td>
+            <td><?php echo htmlspecialchars($msg['subject']); ?></td>
+            <td><?php echo nl2br(htmlspecialchars($msg['message'])); ?></td>
+            <td><?php echo $msg['created_at']; ?></td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
+<p><a href="index.php">Retour au dashboard</a></p>
+</body>
+</html>

--- a/admin/posts.php
+++ b/admin/posts.php
@@ -1,0 +1,15 @@
+<?php
+require '../includes/auth.php';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Gestion des articles</title>
+</head>
+<body>
+<h2>Gestion des articles</h2>
+<p>Cette fonctionnalité sera implémentée ultérieurement.</p>
+<p><a href="index.php">Retour au dashboard</a></p>
+</body>
+</html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -21,3 +21,31 @@ footer {
     padding: 1rem;
     margin-top: 2rem;
 }
+
+/* Layout helpers */
+.container {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 1rem;
+}
+
+.hero {
+    text-align: center;
+    padding: 3rem 0;
+    background: #663399;
+    color: #fff;
+}
+
+.intro {
+    text-align: center;
+    padding: 2rem 0;
+}
+
+.btn {
+    display: inline-block;
+    background: #663399;
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    text-decoration: none;
+}

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,13 @@
+CREATE DATABASE IF NOT EXISTS unico;
+USE unico;
+
+-- Table for contact form submissions
+CREATE TABLE IF NOT EXISTS contacts (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(100) NOT NULL,
+    subject VARCHAR(255) NOT NULL,
+    message TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,0 +1,7 @@
+<?php
+session_start();
+if (!isset($_SESSION['logged_in'])) {
+    header('Location: login.php');
+    exit;
+}
+?>

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,8 +1,9 @@
 <?php
+// Basic PDO connection settings. Adjust credentials as needed.
 $host = 'localhost';
 $db   = 'unico';
-$user = 'root';
-$pass = '';
+$user = 'root'; // change if your MySQL user is different
+$pass = '';     // set your MySQL password if applicable
 $options = [
     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,6 +1,8 @@
 </main>
 <footer>
-    <p>&copy; <?php echo date('Y'); ?> Unico Consult</p>
+    <div class="container">
+        <p>&copy; <?php echo date('Y'); ?> Unico Consult</p>
+    </div>
 </footer>
 </body>
 </html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -10,14 +10,16 @@
     <link rel="stylesheet" href="/assets/css/style.css">
 </head>
 <body>
-<header>
-    <h1>Unico Consult</h1>
-    <nav>
-        <a href="/public/index.php">Accueil</a>
-        <a href="/public/services.php">Services</a>
-        <a href="/public/team.php">Notre équipe</a>
-        <a href="/public/trust.php">Ils nous font confiance</a>
-        <a href="/public/contact.php">Contact</a>
-    </nav>
+<header class="site-header">
+    <div class="container">
+        <h1>Unico Consult</h1>
+        <nav>
+            <a href="/public/index.php">Accueil</a>
+            <a href="/public/services.php">Services</a>
+            <a href="/public/team.php">Notre équipe</a>
+            <a href="/public/trust.php">Ils nous font confiance</a>
+            <a href="/public/contact.php">Contact</a>
+        </nav>
+    </div>
 </header>
-<main>
+<main class="container">

--- a/public/contact.php
+++ b/public/contact.php
@@ -1,5 +1,32 @@
-<?php include '../includes/header.php'; ?>
+<?php
+require '../includes/db.php';
+include '../includes/header.php';
+
+$success = null;
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $subject = trim($_POST['subject'] ?? '');
+    $message = trim($_POST['message'] ?? '');
+
+    if ($name && $email && $subject && $message) {
+        $stmt = $pdo->prepare('INSERT INTO contacts (name, email, subject, message) VALUES (?, ?, ?, ?)');
+        $stmt->execute([$name, $email, $subject, $message]);
+        @mail('info@unico-consult.be', $subject, $message, "From: $name <$email>");
+        $success = 'Votre message a été envoyé.';
+    } else {
+        $error = 'Veuillez remplir tous les champs.';
+    }
+}
+?>
 <h2>Contact</h2>
+<?php if ($success): ?>
+<p style="color:green;"><?php echo $success; ?></p>
+<?php elseif ($error): ?>
+<p style="color:red;"><?php echo $error; ?></p>
+<?php endif; ?>
 <form action="" method="post">
     <label for="name">Nom</label>
     <input type="text" name="name" id="name" required>

--- a/public/index.php
+++ b/public/index.php
@@ -1,4 +1,14 @@
 <?php include '../includes/header.php'; ?>
-<h2>Votre business ? Notre challenge !</h2>
-<p>Bienvenue sur le site d'Unico Consult.</p>
+
+<section class="hero">
+    <h2>Votre business ? Notre challenge&nbsp;!</h2>
+    <p>Bienvenue sur le site d'Unico Consult, votre partenaire en transformation digitale.</p>
+</section>
+
+<section class="intro">
+    <h3>Nos Services</h3>
+    <p>Conseil, développement web et solutions sur mesure pour votre entreprise.</p>
+    <a class="btn" href="/public/services.php">Découvrir nos services</a>
+</section>
+
 <?php include '../includes/footer.php'; ?>

--- a/public/services.php
+++ b/public/services.php
@@ -1,4 +1,11 @@
 <?php include '../includes/header.php'; ?>
 <h2>Nos Services</h2>
-<p>Liste des services à venir.</p>
+<ul>
+    <li>Ressources humaines</li>
+    <li>Gestion d'entreprise</li>
+    <li>Conseil stratégique</li>
+    <li>Outsourcing</li>
+    <li>Logistique</li>
+    <li>Branding et communication</li>
+</ul>
 <?php include '../includes/footer.php'; ?>

--- a/public/team.php
+++ b/public/team.php
@@ -1,4 +1,4 @@
 <?php include '../includes/header.php'; ?>
 <h2>Notre Équipe</h2>
-<p>Présentation de l'équipe.</p>
+<p>Unico Consult a été fondé par <strong>Otman</strong> et <strong>Farid</strong>. Nous mettons nos valeurs de rigueur et d'innovation au service de votre entreprise.</p>
 <?php include '../includes/footer.php'; ?>

--- a/public/trust.php
+++ b/public/trust.php
@@ -1,4 +1,4 @@
 <?php include '../includes/header.php'; ?>
 <h2>Ils nous font confiance</h2>
-<p>Témoignages et logos clients.</p>
+<p>Maison'Net, La Cense et bien d'autres partenaires nous accordent leur confiance.</p>
 <?php include '../includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add user authentication check helper
- show message count in the admin dashboard
- list messages in new admin page
- provide placeholder for posts page
- store contact form submissions in database and send email
- flesh out services, team, and trust pages
- document setup instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841e3cf86ec832d830818ac1b4605e4